### PR TITLE
Fix the CustomEvent's makeWithOption signature.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 * `ofElement` was incorrectly returning `Dom.htmlElement` type instead of the enclosing element type (#60)
 *  `Dom.CssStyleDeclaration.setPropertyValue` was emitting the wrong function name (#114)
 * `Url.toJSON()` was emitting the wrong function name (#121)
+* The `options` signature in `Webapi.Dom.CustomEvent`'s `makeWithOption` (#122)
 
 ### Miscellaneous
 * Converted project to rescript syntax (#18)

--- a/src/Webapi/Dom/Webapi__Dom__CustomEvent.res
+++ b/src/Webapi/Dom/Webapi__Dom__CustomEvent.res
@@ -19,8 +19,9 @@ module Make = (
   include Webapi__Dom__Event.Impl({
     type t = t
   })
+  type options = {detail: Detail.t}
 
   @new external make: string => t = "CustomEvent"
-  @new external makeWithOptions: (string, Detail.t) => t = "CustomEvent"
+  @new external makeWithOptions: (string, options) => t = "CustomEvent"
   @get external detail: t => Detail.t = "detail"
 }


### PR DESCRIPTION
As seen in [1], the options is an object with a `detail` property, not the detail directly.

[1]: https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent