### PR TITLE
fix method parameter for requestInit with rescript v11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
 
 ## main
 
+# 0.9.1
+
+#### :bug: Bug Fix
+
+- Fix binding compatibility with ReScript 11, which removed `_` variable mangling. https://github.com/TheSpyder/rescript-webapi/pull/129
+
 ## 0.9.0
 
 #### :boom: Breaking Change

--- a/src/Webapi/Webapi__Blob.res
+++ b/src/Webapi/Webapi__Blob.res
@@ -7,7 +7,8 @@ module Impl = (
 
   @get external size: T.t => float = "size"
 
-  @send external slice: (T.t, ~start: int=?, ~end_: int=?, ~contentType: string=?, unit) => T.t = "slice"
+  @send
+  external slice: (T.t, ~start: int=?, ~end_: int=?, ~contentType: string=?, unit) => T.t = "slice"
 
   @send external stream: T.t => Webapi__ReadableStream.t = "stream"
 
@@ -27,7 +28,11 @@ type endingType = [#transparent | #native]
 type blobPropertyBag
 
 @obj
-external makeBlobPropertyBag: (~_type: string=?, ~endings: endingType=?, unit) => blobPropertyBag = ""
+external makeBlobPropertyBag: (
+  @as("type") ~_type: string=?,
+  ~endings: endingType=?,
+  unit,
+) => blobPropertyBag = ""
 
 type blobPart
 

--- a/src/Webapi/Webapi__Fetch.res
+++ b/src/Webapi/Webapi__Fetch.res
@@ -309,7 +309,7 @@ module RequestInit = {
 
   @obj
   external make: (
-    ~_method: string=?,
+    @as("method") ~_method: string=?,
     ~headers: headersInit=?,
     ~body: bodyInit=?,
     ~referrer: string=?,
@@ -336,7 +336,7 @@ module RequestInit = {
     ~integrity: string="",
     ~keepalive: option<bool>=?,
     ~signal: option<signal>=?,
-    ()
+    (),
   ) =>
     make(
       ~_method=?map(encodeRequestMethod, method_),
@@ -351,7 +351,7 @@ module RequestInit = {
       ~integrity,
       ~keepalive?,
       ~signal?,
-      ()
+      (),
     )
 }
 
@@ -403,7 +403,7 @@ module ResponseInit = {
     ~status: option<int>=?,
     ~statusText: option<string>=?,
     ~headers: option<headersInit>=?,
-    ()
+    (),
   ) => make(~status?, ~statusText?, ~headers?, ())
 }
 

--- a/src/Webapi/Webapi__File.res
+++ b/src/Webapi/Webapi__File.res
@@ -6,13 +6,12 @@ include Webapi__Blob.Impl({
   type t = t
 })
 
-
 type filePropertyBag
 
 @obj
 external makeFilePropertyBag: (
   ~endings: Webapi__Blob.endingType=?,
-  ~_type: string=?,
+  @as("type") ~_type: string=?,
   ~lastModified: float=?,
   unit,
 ) => filePropertyBag = ""
@@ -20,7 +19,7 @@ external makeFilePropertyBag: (
 @@text("{1 File class}")
 
 @new external make: (array<Webapi__Blob.blobPart>, string) => t = "File"
-@new external makeWithOptions: (array<Webapi__Blob.blobPart>, string, filePropertyBag) => t = "File";
+@new external makeWithOptions: (array<Webapi__Blob.blobPart>, string, filePropertyBag) => t = "File"
 
 @get external lastModified: t => float = "lastModified"
 


### PR DESCRIPTION
Hello, thanks for this package :)

Using `@as` directive as no impact for rescript v9 or v10 but it works in rescript v11

with rescript v9
![image](https://github.com/TheSpyder/rescript-webapi/assets/13664889/9019c54d-6196-46e8-8b63-c91553346a59)
With rescript v10
![image](https://github.com/TheSpyder/rescript-webapi/assets/13664889/d3fe438c-90dc-4d66-937d-0a3250fcf737)
With rescript v11
![image](https://github.com/TheSpyder/rescript-webapi/assets/13664889/adf02c03-27b7-454a-a294-c4d097c68e91)

fix #128 